### PR TITLE
Update travis.tml to fix java8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 sudo: false
 install: true
+dist: trusty
 
 addons:
   sonarcloud:


### PR DESCRIPTION
Java8 is not available in the default distribution so we must specify to use "trusty"
This should fix the Travis build