### PR TITLE
SC-12764 Fix travis CI build to use Ubuntu 22 & JDK17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
+language: java
 sudo: false
 install: true
+
+dist: jammy
+
+jdk: openjdk17
 
 addons:
   sonarcloud:
@@ -9,12 +14,12 @@ addons:
 
 script:
   # JaCoCo is used to have code coverage, "-Pcoverage" activates the maven profile in the pom.xml
-  - mvn clean verify sonar:sonar -Pcoverage 
+  - mvn clean verify sonar:sonar -Pcoverage
 
 cache:
   directories:
-    - '$HOME/.m2/repository'
-    - '$HOME/.sonar/cache'
+    - "$HOME/.m2/repository"
+    - "$HOME/.sonar/cache"
 
 # Don't copy the following part if you're using this project as a starting point of yours
 notifications:


### PR DESCRIPTION
The build is currently broken because java 11 is used to scan this project.

This PR bumps the distribution used in CI from `xenial` to `jammy` (which includes JDK17, and switches java version to it).